### PR TITLE
Respect NuGet package assembly configuration

### DIFF
--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -176,6 +176,11 @@ type IfSharpKernel(connectionInformation : ConnectionInformation, ioSocket : Soc
                 pyout ("NuGet error: " + package.Error)
             else
                 pyout ("NuGet package: " + package.Package.Value.Id)
+                for frameworkAssembly in package.FrameworkAssemblies do
+                    pyout ("Referenced Framework: " + frameworkAssembly.AssemblyName)
+                    let code = String.Format(@"#r @""{0}""", frameworkAssembly.AssemblyName)
+                    fsiEval.EvalInteraction(code)
+
                 for assembly in package.Assemblies do
                     let fullAssembly = compiler.NuGetManager.GetFullAssemblyPath(package, assembly)
                     pyout ("Referenced: " + fullAssembly)


### PR DESCRIPTION
Use filtered assemblies if they are defined and load referenced framework
assemblies.

NuGet packages can specify filters over the assemblies in the lib directories. This is useful if there are native libraries included in the package that are loaded dynamically by the package runtime. The filtered packages should be loaded, rather than the raw package list.

Also, NuGet packages can specify framework or GAC assemblies that are required and should be loaded.
