### PR TITLE
NuGet: Fix handling of packages with AssemblyReferences but not PackageAssemblyReferences

### DIFF
--- a/src/IfSharp.Kernel/NuGetManager.fs
+++ b/src/IfSharp.Kernel/NuGetManager.fs
@@ -197,9 +197,8 @@ type NuGetManager (executingDirectory : string) =
                         elif pkg.AssemblyReferences.IsEmpty() then
                             Seq.empty
                         else
-                            pkg.AssemblyReferences
-                            |> Seq.filter (fun x -> x.TargetFramework = maxFramework)
-                        
+                            getCompatibleItems maxFramework pkg.AssemblyReferences
+
                     let frameworkAssemblyReferences = getCompatibleItems maxFramework pkg.FrameworkAssemblies
 
                     packagesCache.Add(key, { Package = Some pkg; Assemblies = assemblies; FrameworkAssemblies = frameworkAssemblyReferences; Error = ""; })


### PR DESCRIPTION
The previous implementation was breaking with Math.NET Numerics:
- This package also supports Silverlight 5.0, whose version "5.0" is higher than the "4.5" of .Net 4.5. The old implementation did choose the Silverlight build.
- This package includes a build for .Net 4.0 but not a special build for .Net 4.5. The .Net 4.0 build also supports .Net 4.5. The old implementation did an exact match, missing the .Net 4.0 build and thus not referencing anything.
