### PR TITLE
Make build.sh run on Linux

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -101,7 +101,7 @@ Target "Build" (fun _ ->
 
 Target "RunTests" (fun _ ->
     let nunitVersion = GetPackageVersion "packages" "NUnit.Runners"
-    let nunitPath = sprintf "packages/NUnit.Runners.%s/Tools" nunitVersion
+    let nunitPath = sprintf "packages/NUnit.Runners.%s/tools" nunitVersion
     ActivateFinalTarget "CloseTestRunner"
 
     { BaseDirectory = __SOURCE_DIRECTORY__

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ ! -f packages/FAKE/tools/Fake.exe ]; then
-  mono .NuGet/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -Prerelease
+  mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -Prerelease
 fi
 mono packages/FAKE/tools/FAKE.exe build.fsx $@

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ ! -f packages/FAKE/tools/Fake.exe ]; then
+if [ ! -f packages/FAKE/tools/FAKE.exe ]; then
   mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -Prerelease
 fi
 mono packages/FAKE/tools/FAKE.exe build.fsx $@


### PR DESCRIPTION
Hi 

I have Ubuntu installed and F# 4.0 running on Mono on it. I have managed to run build.sh sucessfully after fixing a series of paths typos - case sensitive sort - in build.sh and build.fsx. While on Windows these would not pose problems, I'm sure you know that Linux is not that flexible. 

Might be worth merging this pull request, it won't affect Windows builds but will help Linux ones. 