### PR TITLE
Add a new notebook specific directive "fsioutput" to capture outputs

### DIFF
--- a/src/IfSharp.Kernel/DirectivePreprocessor.fs
+++ b/src/IfSharp.Kernel/DirectivePreprocessor.fs
@@ -1,0 +1,27 @@
+﻿namespace IfSharp.Kernel
+
+module DirectivePreprocessor =
+
+    type Line =
+        | HelpDirective
+        | FSIOutputDirective
+        | NugetDirective
+        | Other
+
+    let determineLineType (idx, (line:string)) =
+        match line.ToLower() with
+        | line when line.StartsWith "#n" -> NugetDirective
+        | line when line.StartsWith "#help" -> HelpDirective
+        | line when line.StartsWith "#fsioutput" -> FSIOutputDirective
+        | _ -> Other
+
+    /// Separates into map of directive types
+    let partitionLines(lines : string[]) =
+        lines
+        |> Seq.mapi (fun (idx) (line) -> (idx, line))
+        |> Seq.groupBy determineLineType
+        |> Map.ofSeq
+
+    /// Parses a directive line. Example: #N "Deedle"
+    let parseDirectiveLine (prefix : string) (line : string) = 
+        line.Substring(prefix.Length + 1).Trim().Trim('"')

--- a/src/IfSharp.Kernel/Evaluation.fs
+++ b/src/IfSharp.Kernel/Evaluation.fs
@@ -8,6 +8,7 @@ open Microsoft.FSharp.Compiler.Interactive.Shell
 [<AutoOpen>]
 module Evaluation = 
 
+    let internal fsiout = ref false
     let internal sbOut = new StringBuilder()
     let internal sbErr = new StringBuilder()
     let internal inStream = new StringReader("")

--- a/src/IfSharp.Kernel/IfSharp.Kernel.fsproj
+++ b/src/IfSharp.Kernel/IfSharp.Kernel.fsproj
@@ -78,6 +78,7 @@
   <ItemGroup>
     <Compile Include="Config.fs" />
     <Compile Include="IfSharpResources.fs" />
+    <Compile Include="DirectivePreprocessor.fs" />
     <Compile Include="NuGetManager.fs" />
     <Compile Include="FsCompiler.fs" />
     <None Include="Include.fsx">

--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -236,6 +236,20 @@ type IfSharpKernel(connectionInformation : ConnectionInformation) =
         let results = compiler.NuGetManager.Preprocess(code)
         let newCode = String.Join("\n", results.FilteredLines)
 
+        if not (Seq.isEmpty results.HelpLines) then
+            fsiEval.EvalInteraction("#help")
+            let ifsharpHelp =
+                """  IF# notebook directives:
+
+    #fsioutput ["on"|"off"];;   Toggle output display on/off
+    """
+            let fsiHelp = sbOut.ToString()
+            pyout (ifsharpHelp + fsiHelp)
+            sbOut.Clear() |> ignore
+
+        if not (Seq.isEmpty results.FsiOutputLines) then
+            fsiout := true
+
         // do nuget stuff
         for package in results.Packages do
             if not (String.IsNullOrWhiteSpace(package.Error)) then
@@ -256,6 +270,9 @@ type IfSharpKernel(connectionInformation : ConnectionInformation) =
 
         if not <| String.IsNullOrEmpty(newCode) then
             fsiEval.EvalInteraction(newCode)
+
+        if fsiout.Value then
+            pyout (sbOut.ToString())
     
     /// Handles an 'execute_request' message
     let executeRequest(msg : KernelMessage) (content : ExecuteRequest) = 

--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -247,8 +247,15 @@ type IfSharpKernel(connectionInformation : ConnectionInformation) =
             pyout (ifsharpHelp + fsiHelp)
             sbOut.Clear() |> ignore
 
+        //This is a persistent toggle, just respect the last one
         if not (Seq.isEmpty results.FsiOutputLines) then
-            fsiout := true
+            let lastFsiOutput = Seq.last results.FsiOutputLines
+            if lastFsiOutput.ToLower().Contains("on") then
+                fsiout := true
+            else if lastFsiOutput.ToLower().Contains("off") then
+                fsiout := false
+            else
+                pyout (sprintf "Unreocognised fsioutput setting: %s" lastFsiOutput)
 
         // do nuget stuff
         for package in results.Packages do


### PR DESCRIPTION
I extended the nuget manager to allow additional directives. This is so that people can turn on showing FSI output particularly for types #63 #43  e.g.

```
In [1]:

  #fsioutput "on"
​
  let x = 2
  x

Out[1]:

  val x : int = 2
  val it : int = 2

Out[1]:

  2
```


I also added trapping of #help as the other directives can also be useful.

Does this seem natural? We're peeling back the abstraction and letting people interact directly with the F# Interactive instance. So if you turn fsioutput on in one cell that will affect other cells until you turn it off again.