### PR TITLE
Auto-Initialise XPlotly.Plotly.fsx and FSCharting.fsx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,9 @@ $RECYCLE.BIN/
 # Exclude F# project specific directories and files
 # ===================================================
 
+# FAKE directory
+.fake/
+
 # NuGet Packages Directory
 packages/
 

--- a/src/IfSharp.Kernel/helpers/FSCharting.fsx
+++ b/src/IfSharp.Kernel/helpers/FSCharting.fsx
@@ -1,6 +1,7 @@
-#nowarn "211"
+[<AutoOpen>]
+module FSCharting
 
-namespace IfSharp
+#nowarn "211"
 
 //#I "../../../bin/packages/FSharp.Charting/lib/net40"
 #I "packages/FSharp.Charting/lib/net40"
@@ -24,116 +25,113 @@ open System.Drawing
 open System.Drawing.Imaging
 open System.Windows.Forms
 
-module FSCharting =
 
-    type GenericChartWithSize =
+type GenericChartWithSize =
+    {
+        Chart: ChartTypes.GenericChart;
+        Size: int * int;
+    }
+type GenericChartsWithSize =
+    {
+        Charts: ChartTypes.GenericChart list;
+        Size: int * int;
+        Columns: int;
+    }
+
+//static member
+let MultipleCharts (charts: ChartTypes.GenericChart list) (size:int*int) (cols:int) =
+    { Charts = charts; Size = size; Columns = cols }
+
+
+type ChartTypes.GenericChart with
+    /// Wraps a GenericChartWithSize around the GenericChart
+    member self.WithSize(x:int, y:int) =
         {
-            Chart: ChartTypes.GenericChart;
-            Size: int * int;
-        }
-    type GenericChartsWithSize =
-        {
-            Charts: ChartTypes.GenericChart list;
-            Size: int * int;
-            Columns: int;
+            Chart = self;
+            Size = (x, y);
         }
 
-    //static member
-    let MultipleCharts (charts: ChartTypes.GenericChart list) (size:int*int) (cols:int) =
-        { Charts = charts; Size = size; Columns = cols }
+    /// Converts the GenericChart to a PNG, in order to do this, we must show a form with ChartControl on it, save the bmp, then write the png to memory
+    member self.ToPng(?size) =
+        // get the size
+        let (width, height) = if size.IsNone then (320, 240) else size.Value
 
+        // create a new ChartControl in order to get the underlying Chart
+        let ctl = new ChartTypes.ChartControl(self)
 
-    type ChartTypes.GenericChart with
-        /// Wraps a GenericChartWithSize around the GenericChart
-        member self.WithSize(x:int, y:int) =
-            {
-              Chart = self;
-              Size = (x, y);
-            }
+        // save
+        use ms = new MemoryStream()
+        let actualChart = ctl.Controls.[0] :?> System.Windows.Forms.DataVisualization.Charting.Chart
+        actualChart.Dock <- DockStyle.None
+        actualChart.Size <- Size(width, height)
+        actualChart.SaveImage(ms, ImageFormat.Png)
+        ms.ToArray()
 
-        /// Converts the GenericChart to a PNG, in order to do this, we must show a form with ChartControl on it, save the bmp, then write the png to memory
-        member self.ToPng(?size) =
-            // get the size
-            let (width, height) = if size.IsNone then (320, 240) else size.Value
+    member self.ToData(?size) =
+        let bytes = match size with Some size -> self.ToPng(size) | _ -> self.ToPng()
+        let base64 = System.Convert.ToBase64String(bytes)
+        let data = "data:image/png;base64,"+base64
+        data
 
-            // create a new ChartControl in order to get the underlying Chart
-            let ctl = new ChartTypes.ChartControl(self)
+type FSharp.Charting.Chart with
 
-            // save
-            use ms = new MemoryStream()
-            let actualChart = ctl.Controls.[0] :?> System.Windows.Forms.DataVisualization.Charting.Chart
-            actualChart.Dock <- DockStyle.None
-            actualChart.Size <- Size(width, height)
-            actualChart.SaveImage(ms, ImageFormat.Png)
-            ms.ToArray()
+    /// Wraps a GenericChartWithSize around the GenericChart
+    static member WithSize(x:int, y:int) =
 
-        member self.ToData(?size) =
-            let bytes = match size with Some size -> self.ToPng(size) | _ -> self.ToPng()
-            let base64 = System.Convert.ToBase64String(bytes)
-            let data = "data:image/png;base64,"+base64
-            data
+        fun (ch : #ChartTypes.GenericChart) ->
+            ch.WithSize(x, y)
 
-    type FSharp.Charting.Chart with
+do
+    Printers.addDisplayPrinter(fun (x:ChartTypes.GenericChart) ->
+        { ContentType = "image/png"; Data = x.ToPng() })
 
-        /// Wraps a GenericChartWithSize around the GenericChart
-        static member WithSize(x:int, y:int) =
-
-            fun (ch : #ChartTypes.GenericChart) ->
-                ch.WithSize(x, y)
+    // add chart printer
+    Printers.addDisplayPrinter(fun (x:GenericChartWithSize) ->
+        { ContentType = "image/png"; Data = x.Chart.ToPng(x.Size) })
 
     // add generic chart printer
-    let Initialize () =
-        Printers.addDisplayPrinter(fun (x:ChartTypes.GenericChart) ->
-            { ContentType = "image/png"; Data = x.ToPng() })
+    Printers.addDisplayPrinter(fun (x:ChartTypes.GenericChart) ->
+        { ContentType = "image/png"; Data = x.ToPng() })
 
-        // add chart printer
-        Printers.addDisplayPrinter(fun (x:GenericChartWithSize) ->
-            { ContentType = "image/png"; Data = x.Chart.ToPng(x.Size) })
-
-        // add generic chart printer
-        Printers.addDisplayPrinter(fun (x:ChartTypes.GenericChart) ->
-            { ContentType = "image/png"; Data = x.ToPng() })
-
-        // add chart printer
-        Printers.addDisplayPrinter(fun (x:GenericChartWithSize) ->
-                    { ContentType = "image/png"; Data = x.Chart.ToPng(x.Size) })
+    // add chart printer
+    Printers.addDisplayPrinter(fun (x:GenericChartWithSize) ->
+                { ContentType = "image/png"; Data = x.Chart.ToPng(x.Size) })
 
 
-        Printers.addDisplayPrinter(fun (x:GenericChartsWithSize) ->
-            let count = x.Charts.Length
-            let (width, height) = x.Size
-            let totalWidth = if count = 1 then width else width * x.Columns
-            let numRows = int (System.Math.Ceiling (float count / float x.Columns))
-            let totalHeight = numRows * height
-            let finalBitmap = new Bitmap(totalWidth, totalHeight)
-            let finalGraphics = Graphics.FromImage(finalBitmap)
-            let copy i (chart:ChartTypes.GenericChart) =
-                let img = chart.ToPng(x.Size)
-                let bitmap = new Bitmap(new MemoryStream(img))
-                finalGraphics.DrawImage(bitmap, i % x.Columns * width, i / x.Columns * height)
-            List.iteri copy x.Charts;
-            finalGraphics.Dispose();
-            let ms = new MemoryStream()
-            finalBitmap.Save(ms, ImageFormat.Png);
-            { ContentType = "image/png"; Data = ms.ToArray() }
-        )
+    Printers.addDisplayPrinter(fun (x:GenericChartsWithSize) ->
+        let count = x.Charts.Length
+        let (width, height) = x.Size
+        let totalWidth = if count = 1 then width else width * x.Columns
+        let numRows = int (System.Math.Ceiling (float count / float x.Columns))
+        let totalHeight = numRows * height
+        let finalBitmap = new Bitmap(totalWidth, totalHeight)
+        let finalGraphics = Graphics.FromImage(finalBitmap)
+        let copy i (chart:ChartTypes.GenericChart) =
+            let img = chart.ToPng(x.Size)
+            let bitmap = new Bitmap(new MemoryStream(img))
+            finalGraphics.DrawImage(bitmap, i % x.Columns * width, i / x.Columns * height)
+        List.iteri copy x.Charts;
+        finalGraphics.Dispose();
+        let ms = new MemoryStream()
+        finalBitmap.Save(ms, ImageFormat.Png);
+        { ContentType = "image/png"; Data = ms.ToArray() }
+    )
 
-        Printers.addDisplayPrinter(fun (x:GenericChartsWithSize) ->
-                  let count = x.Charts.Length
-                  let (width, height) = x.Size
-                  let totalWidth = if count = 1 then width else width * x.Columns
-                  let numRows = int (System.Math.Ceiling (float count / float x.Columns))
-                  let totalHeight = numRows * height
-                  let finalBitmap = new Bitmap(totalWidth, totalHeight)
-                  let finalGraphics = Graphics.FromImage(finalBitmap)
-                  let copy i (chart:ChartTypes.GenericChart) =
-                      let img = chart.ToPng(x.Size)
-                      let bitmap = new Bitmap(new MemoryStream(img))
-                      finalGraphics.DrawImage(bitmap, i % x.Columns * width, i / x.Columns * height)
-                  List.iteri copy x.Charts;
-                  finalGraphics.Dispose();
-                  let ms = new MemoryStream()
-                  finalBitmap.Save(ms, ImageFormat.Png);
-                  { ContentType = "image/png"; Data = ms.ToArray() }
-              )
-    ()
+    Printers.addDisplayPrinter(fun (x:GenericChartsWithSize) ->
+                let count = x.Charts.Length
+                let (width, height) = x.Size
+                let totalWidth = if count = 1 then width else width * x.Columns
+                let numRows = int (System.Math.Ceiling (float count / float x.Columns))
+                let totalHeight = numRows * height
+                let finalBitmap = new Bitmap(totalWidth, totalHeight)
+                let finalGraphics = Graphics.FromImage(finalBitmap)
+                let copy i (chart:ChartTypes.GenericChart) =
+                    let img = chart.ToPng(x.Size)
+                    let bitmap = new Bitmap(new MemoryStream(img))
+                    finalGraphics.DrawImage(bitmap, i % x.Columns * width, i / x.Columns * height)
+                List.iteri copy x.Charts;
+                finalGraphics.Dispose();
+                let ms = new MemoryStream()
+                finalBitmap.Save(ms, ImageFormat.Png);
+                { ContentType = "image/png"; Data = ms.ToArray() }
+            )

--- a/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
+++ b/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
@@ -24,6 +24,19 @@ require = requirejs = define = undefined;
 require = require_save;
 requirejs = requirejs_save;
 define = define_save;
+function ifsharpMakeImage(gd) {
+    var fmt =
+        (document.documentMode || /Edge/.test(navigator.userAgent)) ?
+            'svg' : 'png'
+    return Plotly.toImage(gd, {format: fmt})
+        .then(function(url) {
+            var img = document.createElement('img');
+            img.setAttribute('src', url);
+            var div = document.createElement('div');
+            div.appendChild(img);
+            gd.parentNode.replaceChild(div, gd);
+        });
+}
 </script>
 """
         (wc.DownloadString("https://cdn.plot.ly/plotly-latest.min.js"))
@@ -38,14 +51,7 @@ type XPlot.Plotly.PlotlyChart with
             .Replace("Plotly.newPlot(", "Plotly.plot(")
             .Replace(
                 "data, layout);",
-                """data, layout)
-                .then(function(gd) {
-                    return Plotly.toImage(gd, {format: 'png'})
-                        .then(function(url) {
-                            gd.innerHTML = '<img src=' + url + ' />'
-                        });
-                });
-                """)
+                "data, layout).then(ifsharpMakeImage);")
 
 type XPlot.Plotly.Chart with
 

--- a/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
+++ b/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
@@ -14,3 +14,27 @@ do
 
     { Html = @"<script src=""https://cdn.plot.ly/plotly-latest.min.js""></script>" }
         |> Display
+
+type XPlot.Plotly.PlotlyChart with
+
+    member __.GetPngHtml() =
+        let html = __.GetInlineHtml()
+        html
+            .Replace("Plotly.newPlot(", "Plotly.plot(")
+            .Replace(
+                "data, layout);",
+                """data, layout)
+                .then(function(gd) {
+                    return Plotly.toImage(gd, {format: 'png'})
+                        .then(function(url) {
+                            gd.innerHTML = '<img src=' + url + ' />'
+                        });
+                });
+                """)
+
+type XPlot.Plotly.Chart with
+
+    static member Image (chart: PlotlyChart) =
+        { ContentType = "text/html"
+          Data = chart.GetPngHtml()
+        }

--- a/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
+++ b/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
@@ -12,7 +12,22 @@ do
     Printers.addDisplayPrinter(fun (plot: PlotlyChart) ->
         { ContentType = "text/html"; Data = plot.GetInlineHtml() })
 
-    { Html = @"<script src=""https://cdn.plot.ly/plotly-latest.min.js""></script>" }
+    use wc = new System.Net.WebClient()
+    sprintf
+        """
+<script type="text/javascript">
+var require_save = require;
+var requirejs_save = requirejs;
+var define_save = define;
+require = requirejs = define = undefined;
+%s
+require = require_save;
+requirejs = requirejs_save;
+define = define_save;
+</script>
+"""
+        (wc.DownloadString("https://cdn.plot.ly/plotly-latest.min.js"))
+        |> Util.Html
         |> Display
 
 type XPlot.Plotly.PlotlyChart with

--- a/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
+++ b/src/IfSharp.Kernel/helpers/XPlot.Plotly.fsx
@@ -1,38 +1,16 @@
 #nowarn "211"
-namespace IfSharp
 
 #r "IfSharp.Kernel.dll"
 #I "./packages/XPlot.Plotly/lib/net45/"
 #r "XPlot.Plotly.dll"
 
 open XPlot.Plotly
-
-open System.IO
 open IfSharp.Kernel
 open IfSharp.Kernel.Globals
 
-module Plotly =
-    let plotly_url = "https://cdn.plot.ly/plotly-latest.min.js"
-    let plotly_reference = """<script src="[URL]"></script>""".Replace("[URL]", plotly_url)
+do
+    Printers.addDisplayPrinter(fun (plot: PlotlyChart) ->
+        { ContentType = "text/html"; Data = plot.GetInlineHtml() })
 
-    let react_save = """var require_save = require; var requirejs_save = requirejs; var define_save = define; require=requirejs=define=undefined; """
-    let react_restore = """require = require_save; requirejs = requirejs_save; define = define_save;"""
-
-    let plotly_include = """
-<script type="text/javascript">
-    [PLOTLY_JS]
-</script>"""
-
-    let script_template =
-        """Plotly.plot("[ID]", [DATA], [LAYOUT], [CONFIG]).then(function() {
-    $(".[ID].loading").remove()
-})"""
-
-    let InitialiseNotebook () =
-        let wc = new System.Net.WebClient()
-        let plotlyjs = react_save + wc.DownloadString(plotly_url) + react_restore
-        plotly_include.Replace("[PLOTLY_JS]", plotlyjs) |> Util.Html
-
-    let Show (plot:XPlot.Plotly.PlotlyChart) = 
-        plot.GetInlineHtml () |> Util.Html
-      
+    { Html = @"<script src=""https://cdn.plot.ly/plotly-latest.min.js""></script>" }
+        |> Display


### PR DESCRIPTION
This change automatically initialises Display printers and uses
`[<AutoOpen>]` to expose the extension methods. As a result, the
notebook user only needs to #load the helper script, and doesn't
need to know a module name to open or an initialisation function
to run.

This change uses `addDisplayPrinter` to make XPlot charts display
in the same way as other elements. It also changes the way the
plot.ly JavaScript is loaded such that it is loaded in the notebook
browser when the script is loaded, without needing an initialisation
call.

Plotly has many lovely features, but large data sets rendered as
JavaScript can be difficult to deal with. This adds Chart.Image,
which renders a chart as a static PNG.