### PR TITLE
Add a Paket.fsx script

### DIFF
--- a/src/IfSharp.Kernel/helpers/Paket.fsx
+++ b/src/IfSharp.Kernel/helpers/Paket.fsx
@@ -1,0 +1,13 @@
+[<AutoOpen>]
+module IfSharpPaket
+
+#nowarn "211"
+
+#r "Paket.Core.dll"
+
+open System
+
+let private dir =
+  IO.Path.GetDirectoryName(Reflection.Assembly.GetEntryAssembly().Location)
+
+let paket = Paket.Dependencies.Locate(dir)

--- a/src/IfSharp.Kernel/helpers/Paket.fsx
+++ b/src/IfSharp.Kernel/helpers/Paket.fsx
@@ -1,13 +1,22 @@
-[<AutoOpen>]
-module IfSharpPaket
-
 #nowarn "211"
 
+#r "Chessie.dll"
 #r "Paket.Core.dll"
 
 open System
 
-let private dir =
-  IO.Path.GetDirectoryName(Reflection.Assembly.GetEntryAssembly().Location)
+module Paket =
+    let private dir =
+        Reflection.Assembly.GetEntryAssembly().Location
+        |> IO.Path.GetDirectoryName
 
-let paket = Paket.Dependencies.Locate(dir)
+    Paket.Dependencies.Init(dir)
+    let deps = Paket.Dependencies.Locate(dir)
+
+    let Package list =
+        for package in list do
+           deps.Add(package)
+
+    let Version list =
+        for package, version in list do
+            deps.Add(None, package, version)

--- a/src/IfSharp.Kernel/helpers/Paket.fsx
+++ b/src/IfSharp.Kernel/helpers/Paket.fsx
@@ -5,18 +5,17 @@
 
 open System
 
-module Paket =
-    let private dir =
-        Reflection.Assembly.GetEntryAssembly().Location
-        |> IO.Path.GetDirectoryName
+let private dir =
+    Reflection.Assembly.GetEntryAssembly().Location
+    |> IO.Path.GetDirectoryName
 
-    Paket.Dependencies.Init(dir)
-    let deps = Paket.Dependencies.Locate(dir)
+Paket.Dependencies.Init(dir)
+let deps = Paket.Dependencies.Locate(dir)
 
-    let Package list =
-        for package in list do
-           deps.Add(package)
+let Package list =
+    for package in list do
+        deps.Add(package)
 
-    let Version list =
-        for package, version in list do
-            deps.Add(None, package, version)
+let Version list =
+    for package, version in list do
+        deps.Add(None, package, version)


### PR DESCRIPTION
This script loads `Paket.Core.dll` and sets up a `paket` object that
is an instance of `Paket.Dependencies` that is initialised from
`bin/paket.dependencies`. This allows simple use of Paket from
jupyter, like this:

```fsharp
Paket.Package
  [ "Some.Package"
    "Another.Package"
  ]
```