### PR TITLE
Install option

### DIFF
--- a/src/IfSharp.Kernel/App.fs
+++ b/src/IfSharp.Kernel/App.fs
@@ -142,11 +142,10 @@ module App =
         // add to the payload
         Kernel.Value.AddPayload(text.ToString())
 
-    /// Installs the ifsharp files if they do not exist, then starts jupyter with the ifsharp profile
-    let InstallAndStart(forceInstall, start) = 
+    /// Installs the ifsharp files if they do not exist
+    let Install forceInstall = 
 
         let thisExecutable = Assembly.GetEntryAssembly().Location
-        let userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         let kernelDir = Config.KernelDir
         let staticDir = Config.StaticDir
         let tempDir = Config.TempDir
@@ -251,28 +250,33 @@ module App =
             with
                 | ex -> printfn "Paket install failed, may be related to:%s\n%s" "https://github.com/fsprojects/Paket/issues/1918" ex.Message
 
-        if start then
-          (
-          printfn "Starting ipython..."
-          let p = new Process()
-          p.StartInfo.FileName <- "jupyter"
-          p.StartInfo.Arguments <- "notebook"
-          p.StartInfo.WorkingDirectory <- userDir
+    /// Starts jupyter in the user's home directory
+    let StartJupyter () =
 
-          // tell the user something bad happened
-          if p.Start() = false then printfn "Unable to start jupyter, please install jupyter first"
-          )
+        let userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+        printfn "Starting ipython..."
+        let p = new Process()
+        p.StartInfo.FileName <- "jupyter"
+        p.StartInfo.Arguments <- "notebook"
+        p.StartInfo.WorkingDirectory <- userDir
+
+        // tell the user something bad happened
+        if p.Start() = false then printfn "Unable to start jupyter, please install jupyter first"
 
     /// First argument must be an ipython connection file, blocks forever
     let Start (args : array<string>) = 
 
         if args.Length = 0 then
-        
-            InstallAndStart(true, true)
+            Install true
+            StartJupyter()
+
+        else if args.[0] = "--install" then
+            Install true
 
         else
             // Verify kernel installation status
-            InstallAndStart(false, false)
+            Install false
 
             // Clear the temporary folder
             try


### PR DESCRIPTION
Previously, ifsharp.exe would always try to run jupyter. This is not
the desired behaviour in some instances (for example, in a Docker
container, where jupyter must be started with specific command line
options).

This change adds a `--install` option that installs the IfSharp
kernel without trying to start jupyter.