### PR TITLE
Kernelspecs

### DIFF
--- a/ipython-profile/kernel.js
+++ b/ipython-profile/kernel.js
@@ -1,6 +1,7 @@
 define(function () {
 
-    var staticFolder = "/kernelspecs/ifsharp/static/";
+    var kernelSpecs = requirejs.s.contexts._.config.paths.kernelspecs
+    var staticFolder = kernelSpecs + "/ifsharp/static/";
 
     var link = document.createElement("link");
     link.type = "text/css";

--- a/ipython-profile/kernel.js
+++ b/ipython-profile/kernel.js
@@ -157,10 +157,6 @@ define(function () {
             });
         });
 
-        // replace the image
-        var img = $('.container img')[0];
-        img.src = staticFolder + "custom/ifsharp_logo.png";
-
     }
 
     return { onload: onload }

--- a/ipython-profile/kernel.js
+++ b/ipython-profile/kernel.js
@@ -1,6 +1,6 @@
 define(function () {
 
-    var kernelSpecs = requirejs.s.contexts._.config.paths.kernelspecs
+    var kernelSpecs = requirejs.s.contexts._.config.paths.kernelspecs;
     var staticFolder = kernelSpecs + "/ifsharp/static/";
 
     var link = document.createElement("link");

--- a/kernel-spec/kernel.json
+++ b/kernel-spec/kernel.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "IFSharp",
+  "display_name": "F#",
   "argv": ["mono", "%s", "{connection_file}"],
   "language": "fsharp"
 }


### PR DESCRIPTION
This correctly respects the kernelspecs path set by Jupyter. It also places the F# logo only in the "normal" place, allowing the Jupyter logo to display in the upper left (as other kernels do). The display name is changed from IFSharp (the kernel name) to F# (the language name) to match other kernels.