### PR TITLE
Give users assistance converting from #N

### DIFF
--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -256,6 +256,23 @@ type IfSharpKernel(connectionInformation : ConnectionInformation) =
             else
                 pyout (sprintf "Unreocognised fsioutput setting: %s" lastFsiOutput)
 
+        if Array.length results.NuGetLines > 0 then
+
+            let nugets =
+                results.NuGetLines
+                |> (Seq.map compiler.NuGetManager.ParseNugetLine >> Seq.map (fun (name, version, pre) -> "\"" + name + "\""))
+                |> (String.concat "; ")
+
+            let message =
+                sprintf
+                    """Instead of #N please get NuGets by Paket (https://fsprojects.github.io/Paket/) e.g. %s%s#load "Paket.fsx"%sPaket.Package [%s]"""
+                    Environment.NewLine
+                    Environment.NewLine
+                    Environment.NewLine
+                    nugets
+
+            pyout message
+
         // do nuget stuff
         for package in results.Packages do
             if not (String.IsNullOrWhiteSpace(package.Error)) then

--- a/src/IfSharp.Kernel/NuGetManager.fs
+++ b/src/IfSharp.Kernel/NuGetManager.fs
@@ -121,6 +121,9 @@ type NuGetManager (executingDirectory : string) =
     /// Downloads a nuget package by the specified name
     member this.DownloadNugetPackage (nugetPackage : string, version : Option<string>, prerelease : bool) =
         
+
+
+
         let version = defaultArg version ""
         let key = String.Format("{0}/{1}/{2}", nugetPackage, version, prerelease)
 
@@ -240,7 +243,9 @@ type NuGetManager (executingDirectory : string) =
         let nugetLines = DirectivePreprocessor.Line.NugetDirective |> orEmpty
         let otherLines = DirectivePreprocessor.Line.Other |> orEmpty
 
-        // parse the nuget lines and then download the packages
+        //This broke: https://github.com/fsprojects/IfSharp/issues/106
+
+        (*// parse the nuget lines and then download the packages
         let nugetPackages =
             nugetLines
             |> Seq.map (fun (idx, line) -> (idx, this.ParseNugetLine(line)))
@@ -251,8 +256,8 @@ type NuGetManager (executingDirectory : string) =
         let errors =
             nugetPackages
             |> Seq.filter (fun (_, package) -> String.IsNullOrEmpty(package.Error) = false)
-            |> Seq.map (fun (idx, package) -> CustomErrorInfo.From("", idx, 0, idx, lines.[idx].Length, package.Error, "Error", "preprocess"))
-            |> Seq.toArray
+            |> Seq.map (fun (idx, package) -> CustomErrorInfo.From("", idx, 0, idx, lines.[idx].Length, "Please switch to Paket", "Error", "preprocess"))
+            |> Seq.toArray*)
 
         {
             OriginalLines = lines;
@@ -261,6 +266,6 @@ type NuGetManager (executingDirectory : string) =
             NuGetLines = nugetLines |> Seq.map(fun (_, line) -> line) |> Seq.toArray;
             
             FilteredLines = otherLines |> Seq.map(fun (_, line) -> line) |> Seq.toArray;
-            Packages = nugetPackages |> Seq.map(fun (_, package) -> package) |> Seq.toArray;
-            Errors = errors;
+            Packages = Array.empty //nugetPackages |> Seq.map(fun (_, package) -> package) |> Seq.toArray;
+            Errors = Array.empty //errors;
         }


### PR DESCRIPTION
#N for getting NuGets is currently non-functional, see #106 

Paket is a generally better way to get NuGets and users would generally be better off switching to Paket now. This change gives some assistance in switching off #N syntax.

![image](https://cloud.githubusercontent.com/assets/1099725/20844545/3aa21e74-b8b8-11e6-957c-0fd6fbd4dd6f.png)

We would be able to remove the very old \lib\NuGet.dll if we were to do this.

The main missing feature is that the #N syntax also automatically referenced the dlls for you, see: `frameworkAssemblyReferences`.

We could either do without that given that Paket acquires packages without version numbers in the directories or attempt to implement it again in a cross-framework way.