### PR TITLE
Generate the referencing scripts

### DIFF
--- a/src/IfSharp.Kernel/helpers/Paket.Generated.Refs.fsx
+++ b/src/IfSharp.Kernel/helpers/Paket.Generated.Refs.fsx
@@ -1,0 +1,1 @@
+#load "paket-files/include-scripts/net451/include.main.group.fsx"

--- a/src/IfSharp.Kernel/helpers/Paket.fsx
+++ b/src/IfSharp.Kernel/helpers/Paket.fsx
@@ -28,20 +28,22 @@ let private add package version =
         installAfter = false, semVerUpdateMode = SemVerUpdateMode.NoRestriction,
         touchAffectedRefs = false)
 
+let private generateScripts() =
+    //The framework version needs to be kept in sync with the kernel
+    generateScriptsForRootFolder FSharp (Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5_1) (System.IO.DirectoryInfo __SOURCE_DIRECTORY__)
+
 let Package list =
     for package in list do
         add package ""
 
-    generateScriptsForRootFolder FSharp (Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5_1)  (System.IO.DirectoryInfo __SOURCE_DIRECTORY__)
+    generateScripts()
 
     deps.Install(false)
-
-    
 
 let Version list =
     for package, version in list do
         add package version
 
-    generateScriptsForRootFolder FSharp (Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5_1)  (System.IO.DirectoryInfo __SOURCE_DIRECTORY__)
+    generateScripts()
 
     deps.Install(false)

--- a/src/IfSharp.Kernel/helpers/Paket.fsx
+++ b/src/IfSharp.Kernel/helpers/Paket.fsx
@@ -4,6 +4,7 @@
 
 open System
 open Paket
+open Paket.LoadingScripts.ScriptGeneration
 
 let deps =
     let dir =
@@ -31,10 +32,16 @@ let Package list =
     for package in list do
         add package ""
 
+    generateScriptsForRootFolder FSharp (Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5_1)  (System.IO.DirectoryInfo __SOURCE_DIRECTORY__)
+
     deps.Install(false)
+
+    
 
 let Version list =
     for package, version in list do
         add package version
+
+    generateScriptsForRootFolder FSharp (Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5_1)  (System.IO.DirectoryInfo __SOURCE_DIRECTORY__)
 
     deps.Install(false)


### PR DESCRIPTION
This allows the start of the notebook to be like this:

```fsharp
#load "Paket.fsx"
Paket.Package
  [ "MathNet.Numerics"
    "MathNet.Numerics.FSharp"
  ]
#load "Paket.Generated.Refs.fsx"
```

I used Paket.Generated.Refs.fsx avoiding overlap with https://github.com/fsprojects/Paket/issues/1943 alternatively all-references.fsx could also work etc.

It's less noisy and there's less magic going on but still less explicit than getting users to reference their own dlls. Thoughts? Rather than extend the Package and Version functions, we could have a separate ReferencePackages() function.

it's encapsulated a lot of the other concerns compared to the full syntax in #106 

```fsharp
#load "Paket.fsx"

Paket.Dependencies.Install """
frameworks: net451
source https://nuget.org/api/v2
nuget MathNet.Numerics
nuget MathNet.Numerics.FSharp
"""

Paket.LoadingScripts.ScriptGeneration.generateScriptsForRootFolder Paket.LoadingScripts.ScriptGeneration.FSharp (Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5_1)  (System.IO.DirectoryInfo __SOURCE_DIRECTORY__)
```
then
```
#load "paket-files/include-scripts/net451/include.main.group.fsx"
```