### PR TITLE
Display Standard Out

### DIFF
--- a/src/IfSharp.Kernel/App.fs
+++ b/src/IfSharp.Kernel/App.fs
@@ -47,6 +47,10 @@ module App =
     let Display (value : obj) =
 
         if value <> null then
+            if sbPrint.Length > 0 then
+                Kernel.Value.SendDisplayData("text/plain", sbPrint.ToString())
+                sbPrint.Clear() |> ignore
+
             let printer = Printers.findDisplayPrinter(value.GetType())
             let (_, callback) = printer
             let callbackValue = callback(value)

--- a/src/IfSharp.Kernel/Evaluation.fs
+++ b/src/IfSharp.Kernel/Evaluation.fs
@@ -33,9 +33,11 @@ module Evaluation =
     let internal startSession () =
         let sbOut = new StringBuilder()
         let sbErr = new StringBuilder()
+        let sbPrint = new StringBuilder()
         let inStream = new StringReader("")
         let outStream = new StringWriter(sbOut)
         let errStream = new StringWriter(sbErr)
+        let printStream = new StringWriter(sbPrint)
     
         let fsiObj = Microsoft.FSharp.Compiler.Interactive.Settings.fsi
         let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration(fsiObj, false)
@@ -54,10 +56,12 @@ module Evaluation =
         let extraPrinters = 
           unbox<ResizeArray<System.Type * (obj -> seq<string * string> * string)>>
             (fsiSession.EvalExpression("FsInteractiveService.htmlPrinters").Value.ReflectionValue)
-        sbErr, sbOut, extraPrinters, fsiSession
+
+        Console.SetOut(printStream)
+        sbErr, sbOut, sbPrint, extraPrinters, fsiSession
 
     let internal fsiout = ref false
-    let internal sbErr, sbOut, extraPrinters, fsiEval = startSession ()
+    let internal sbErr, sbOut, sbPrint, extraPrinters, fsiEval = startSession ()
 
     /// Gets `it` only if `it` was printed to the console
     let GetLastExpression() =

--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -303,6 +303,7 @@ type IfSharpKernel(connectionInformation : ConnectionInformation) =
         // clear some state
         sbOut.Clear() |> ignore
         sbErr.Clear() |> ignore
+        sbPrint.Clear() |> ignore
         payload.Clear()
 
         // only increment if we are not silent
@@ -322,6 +323,9 @@ type IfSharpKernel(connectionInformation : ConnectionInformation) =
             | exn -> 
                 handleException exn
                 Some exn
+
+        if sbPrint.Length > 0 then
+            sendDisplayData "text/plain" (sbPrint.ToString()) "display_data"
 
         if sbErr.Length > 0 then
             let err = sbErr.ToString().Trim()
@@ -353,11 +357,11 @@ type IfSharpKernel(connectionInformation : ConnectionInformation) =
                 let lastExpression = GetLastExpression()
                 match lastExpression with
                 | Some(it) -> 
-                        
-                    let printer = Printers.findDisplayPrinter(it.ReflectionType)
-                    let (_, callback) = printer
-                    let callbackValue = callback(it.ReflectionValue)
-                    sendDisplayData callbackValue.ContentType callbackValue.Data "pyout"
+                    if it.ReflectionType <> typeof<unit> then
+                        let printer = Printers.findDisplayPrinter(it.ReflectionType)
+                        let (_, callback) = printer
+                        let callbackValue = callback(it.ReflectionValue)
+                        sendDisplayData callbackValue.ContentType callbackValue.Data "pyout"
 
                 | None -> ()
 


### PR DESCRIPTION
Attach a string builder as System.Console.Out and send its contents
to the notebook on Display and when execution completes.

Do not send a "pyout" message when the result of a cell is of type
unit, in order to avoid printing "<null>".