### PR TITLE
Provide function signature by default

### DIFF
--- a/src/IfSharp.Kernel/Printers.fs
+++ b/src/IfSharp.Kernel/Printers.fs
@@ -3,9 +3,6 @@
 open System
 open System.Text
 open System.Web
-//open System.Drawing
-//open System.Drawing.Imaging
-//open System.IO
 
 module Printers =
 
@@ -22,12 +19,43 @@ module Printers =
     let defaultDisplayPrinter(x) =
         { ContentType = "text/plain"; Data = sprintf "%A" x }
 
+    //https://technet.microsoft.com/en-us/ee353649(v=vs.85)
+    let mapToFSharpAliases fullType name =
+        //Attempt to use more standard F# types in signature
+        match fullType with
+        //| array<'T> -> ""
+        | _ when fullType = typeof<System.Numerics.BigInteger> -> "bigint"
+        | _ when fullType = typeof<System.Boolean> -> "bool"
+        | _ when fullType = typeof<System.Byte> -> "byte"
+        | _ when fullType = typeof<System.Char> -> "char"
+        | _ when fullType = typeof<System.Decimal> -> "decimal"
+        | _ when fullType = typeof<System.Double> -> "double"
+        | _ when fullType = typeof<System.Exception> -> "exn"
+        | _ when fullType = typeof<System.Single> -> "single"
+        //| "Format<'Printer,'State,'Residue,'Result,'Tuple> Type of a formatting expression.
+        //| "Format<'Printer,'State,'Residue,'Result> Type of a formatting expression.
+        | _ when fullType = typeof<System.Int16> -> "int16"
+        | _ when fullType = typeof<System.Int32> -> "int"
+        | _ when fullType = typeof<System.Int64> -> "int64"
+        | _ when fullType = typeof<System.IntPtr> -> "nativeint"
+        | _ when fullType = typeof<System.Object> -> "obj"
+        | _ when fullType = typeof<System.SByte> -> "sbyte"
+        | _ when fullType = typeof<System.Single> -> "single"
+        | _ when fullType = typeof<System.String> -> "string"
+        | _ when fullType = typeof<System.UInt16> -> "uint16"
+        | _ when fullType = typeof<System.UInt32> -> "uint32"
+        | _ when fullType = typeof<System.UInt64> -> "uint64"
+        | _ when fullType = typeof<System.Byte> -> "uint8"
+        | _ when fullType = typeof<System.UIntPtr> -> "unativeint"
+        //Unit
+        | _ -> name
+
     let rec possiblyAFuncAsString(p) =
         if FSharp.Reflection.FSharpType.IsFunction p then
-             let fromType, toType = FSharp.Reflection.FSharpType.GetFunctionElements p
-             sprintf "(%s -> %s)" (possiblyAFuncAsString fromType) (possiblyAFuncAsString toType)
+            let fromType, toType = FSharp.Reflection.FSharpType.GetFunctionElements p
+            sprintf "(%s -> %s)" (possiblyAFuncAsString fromType) (possiblyAFuncAsString toType)
         else
-            p.Name
+            mapToFSharpAliases p p.Name
 
     let functionPrinter(func:obj) =
         let funcArguments = possiblyAFuncAsString (func.GetType())


### PR DESCRIPTION
We print the last expression of a cell, which for some types like FSharpFunc leads to less information than on FSI:

```
 In[1]: let addTwo = (+) 2
        addTwo
Out[1]: <fun:addTwo@1-10>
```
As reported on #125. There are various workarounds e.g. .GetType().BaseType or as I suggest on the issue turning on fsioutput. That's nice to have as an option but for _functions_ we can have a better default:

```fsharp
let addTwo = (+) 2
addTwo
```
now produces:
```
<fun:addTwo@1-1> : (Int32 -> Int32)
```
It uses reflection rather than the F# which means everything is in CLR types so there are differences to FSI e.g.
```fsharp
let addHigher f g = ((f 2) 3) + (g 2 3) + 5
addHigher
```
in the notebook:
```
<fun:it@2> : ((Int32 -> (Int32 -> Int32)) -> ((Int32 -> (Int32 -> Int32)) -> Int32))
```
while fsi:
```
val it : ((int -> int -> int) -> (int -> int -> int) -> int)
```
it might be possible to move them closer but from the obj I'm lacking in context and this seems to get a lot of the benefit.