### PR TITLE
fix up the Download URL for the Manual Installation (Linux) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The workaround is for IPython/Jupyter changes will be fixed in a future release.
 # Manual Installation (Linux)
 1. Install [Jupyter](http://jupyter.readthedocs.org/en/latest/install.html) via pip or Anaconda etc.
 2. Install [Mono](http://www.mono-project.com/docs/getting-started/install/linux/) (tested 4.2.4) and F# (tested 4.0). (warning: Mono 4.6 does *not* work due to a [networking bug](https://github.com/fsprojects/IfSharp/issues/90) which is addressed in the upcoming Mono 4.8)
-3. Download the current IfSharp zip release [v3.0.0-beta1](https://github.com/fsprojects/IfSharp/releases/download/v3.0.0-alpha4/IfSharp.v3.0.0-beta1.zip)
+3. Download the current IfSharp zip release [v3.0.0-beta1](https://github.com/fsprojects/IfSharp/releases/download/v3.0.0-beta1/IfSharp.v3.0.0-beta1.zip)
 4. Unzip the release to a safe place such as `~/opt/ifsharp`.
 5. Run `mono ~/opt/ifsharp/IfSharp.exe` to set up the jupyter config files in `~/.jupyter/` and `~/.local/share/jupyter/kernels/ifsharp/`.
   1. (For XPlot) From the install directory `~/opt/` run `mono paket.bootstrapper.exe` then `mono paket.exe install` 


### PR DESCRIPTION
There's a tiny typo in the URL for the linux manual installation section - it's currently a broken link