### PR TITLE
Updateerrors

### DIFF
--- a/ipython-profile/kernel.js
+++ b/ipython-profile/kernel.js
@@ -11,6 +11,8 @@ define(function () {
 
     var changedSinceTypecheck = true;
     var changedRecently = false;
+    var kernelIdledSinceTypeCheck = false;
+    var kernelIdledRecently = false
 
     var onload = function () {
 
@@ -160,18 +162,29 @@ define(function () {
                         data.cell.code_mirror.intellisense.setDeclarations([])
                     });
 
+                    $([IPython.events]).on('kernel_idle.Kernel', function (event, data) {
+                        kernelIdledSinceTypeCheck = true;
+                        kernelIdledRecently = true;
+                    });
+
+
+
                     window.setInterval(function () {
-                        if (!changedSinceTypecheck)
+                        if (!changedSinceTypecheck && !kernelIdledSinceTypeCheck)
                             return;
 
-                        if (changedRecently) {
+                        if (changedRecently || kernelIdledRecently) {
                             changedRecently = false;
+                            kernelIdledRecently = false;
                             return;
                         }
 
                         changedSinceTypecheck = false;
                         changedRecently = false;
+                        kernelIdledSinceTypeCheck = false;
+                        kernelIdledRecently = false;
                         intellisenseRequest({ keyCode: 0 })
+                        console.log("requesting intellisense");
                     }, 1000);
 
                 });

--- a/ipython-profile/kernel.js
+++ b/ipython-profile/kernel.js
@@ -184,7 +184,6 @@ define(function () {
                         kernelIdledSinceTypeCheck = false;
                         kernelIdledRecently = false;
                         intellisenseRequest({ keyCode: 0 })
-                        console.log("requesting intellisense");
                     }, 1000);
 
                 });


### PR DESCRIPTION
When you use e.g. Paket then dependent code's error highlighting won't be updated until you actually edit a cell. If you're running someone else's notebook you might not change cells especially if it looks like there are errors. 

![image](https://cloud.githubusercontent.com/assets/1099725/24009263/59c80d9e-0a6c-11e7-91e3-7931b363a068.png)

This change means that as you execute the notebook (and it goes idle) then intellisense requests will be made and the errors go.