### PR TITLE
Base Dockerfile on mono:5.4.0.201

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM ubuntu:16.04
+FROM mono:5.4.0.201
 
-RUN apt-key adv \
-        --keyserver hkp://keyserver.ubuntu.com:80 \
-        --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.4 main" | \
-        tee /etc/apt/sources.list.d/mono-xamarin.list \
-    && apt-get update \
-    && apt-get install -y \
-        mono-complete \
-        fsharp \
+RUN apt update \
+    && apt install -y \
         python3-pip \
-        git \
-    && rm -rf /var/lib/apt/lists/*
+        git
 
-RUN pip3 install --upgrade pip && pip3 install jupyter
+RUN pip3 install --upgrade setuptools pip
+RUN pip3 install jupyter
 
 WORKDIR /
 RUN git clone https://github.com/fsprojects/IfSharp.git
@@ -33,5 +26,6 @@ ENTRYPOINT ["jupyter", \
             "--no-browser", \
             "--ip='*'", \
             "--port=8888", \
-            "--notebook-dir=/notebooks" \
+            "--notebook-dir=/notebooks", \
+	    "--allow-root" \
             ]


### PR DESCRIPTION
In order to avoid certificate issues with Paket and use the --allow-root flag for Jupyter in order to start the container directly

Use the "docker exec <container_id> jupyter notebook list" to get the token to log in once the container is started