### PR TITLE
Added a paket reference to FSharp.Compiler.Tools

### DIFF
--- a/src/IfSharp.Kernel/paket.references
+++ b/src/IfSharp.Kernel/paket.references
@@ -3,3 +3,4 @@ NetMQ
 Newtonsoft.Json
 Paket.Core
 FSharp.Core
+FSharp.Compiler.Tools


### PR DESCRIPTION
I needed it in order to build in VS2017