### PR TITLE
Remove build warnings of files added twice

### DIFF
--- a/src/IfSharpConsole/IfSharpConsole.csproj
+++ b/src/IfSharpConsole/IfSharpConsole.csproj
@@ -96,12 +96,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <CopyHelpers Include="..\IfSharp.Kernel\helpers\XPlot.GoogleCharts.fsx">
-      <Link>XPlot.GoogleCharts.fsx</Link>
-    </CopyHelpers>
-    <CopyHelpers Include="..\IfSharp.Kernel\helpers\XPlot.GoogleCharts.Paket.fsx">
-      <Link>XPlot.GoogleCharts.Paket.fsx</Link>
-    </CopyHelpers>
     <CopyHelpers Include="..\IfSharp.Kernel\helpers\plotly-latest.min.js">
       <Link>plotly-latest.min.js</Link>
     </CopyHelpers>


### PR DESCRIPTION
I get the following warnings when building in VS2017 (and the files should be included in the *.fsx include a couple of lines down)

![image](https://user-images.githubusercontent.com/10380995/32568714-5bcd96e6-c4bf-11e7-8cf8-82af0e198f20.png)