### PR TITLE
Enabling jupiter themes

### DIFF
--- a/ipython-profile/kernel.js
+++ b/ipython-profile/kernel.js
@@ -126,7 +126,6 @@ define(function () {
                     var editor = cell.code_mirror;
                     if (editor.intellisense == null) {
                         var intellisense = new CodeMirrorIntellisense(editor);
-                        editor.setOption('theme', 'neat');
                         editor.intellisense = intellisense;
 
                         editor.on('changes', function (cm, changes) {

--- a/ipython-profile/static/custom/fsharp.css
+++ b/ipython-profile/static/custom/fsharp.css
@@ -175,22 +175,3 @@ th {
 .icon-glyph-1001 {
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAoklEQVR4XsXTPQ6CQBCG4Q8ksTAbrb2BB6CioLT0Cl7Bxmt4Bc9gZwmJieEChsKCUkMFFT9hCJspiAVxGRKeevPObDZrEREkbAg5AJDfTwS2UNvbyjsfMKC/dXcFHVD+DjoWvPAvtb9YDn5waFB/kA5USYjs8YGJOok5wJauZxZ4x5O9AiOSBaguhYGqmHmDJv3CXm9GB45l9LzCjD4//29sAVazOELv0oQIAAAAAElFTkSuQmCC);
 }
-
-.cm-s-neat span.cm-comment { color: #008000; }
-.cm-s-neat span.cm-keyword { line-height: 1em; font-weight: bold; color: blue; }
-.cm-s-neat span.cm-string { color: #B21543; }
-.cm-s-neat span.cm-builtin { line-height: 1em; font-weight: bold; color: #077; }
-.cm-s-neat span.cm-special { line-height: 1em; font-weight: bold; color: #0aa; }
-.cm-s-neat span.cm-variable { color: black; }
-.cm-s-neat span.cm-number, .cm-s-neat span.cm-atom { color: #3a3; }
-.cm-s-neat span.cm-meta {color: #555;}
-.cm-s-neat span.cm-link { color: #3a3; }
-
-.cm-s-neat .CodeMirror-activeline-background {background: #e8f2ff !important;}
-.cm-s-neat .CodeMirror-matchingbracket {outline:1px solid grey; color:black !important;}
-
-.cm-s-neat.CodeMirror {
-    font-family: "Fira Code", Consolas, Monaco, Menlo, "Andale Mono", "lucida console", "Courier New", monospace !important;
-    font-feature-settings: "calt" 1;
-    box-shadow: inset 0 0 2px black;
-}


### PR DESCRIPTION
Removed hardcoded theme and custom css for the theme. Instead preferred F# code coloring can be applied by setting one of the Jupiter themes (e.g., using projects like jupyter-themes).

Closes #148 