### PR TITLE
Jupyter themes and VisualStudio theme for f#

### DIFF
--- a/ipython-profile/kernel.js
+++ b/ipython-profile/kernel.js
@@ -126,7 +126,6 @@ define(function () {
                     var editor = cell.code_mirror;
                     if (editor.intellisense == null) {
                         var intellisense = new CodeMirrorIntellisense(editor);
-                        editor.setOption('theme', 'neat');
                         editor.intellisense = intellisense;
 
                         editor.on('changes', function (cm, changes) {

--- a/ipython-profile/static/custom/fsharp.css
+++ b/ipython-profile/static/custom/fsharp.css
@@ -176,21 +176,26 @@ th {
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAoklEQVR4XsXTPQ6CQBCG4Q8ksTAbrb2BB6CioLT0Cl7Bxmt4Bc9gZwmJieEChsKCUkMFFT9hCJspiAVxGRKeevPObDZrEREkbAg5AJDfTwS2UNvbyjsfMKC/dXcFHVD+DjoWvPAvtb9YDn5waFB/kA5USYjs8YGJOok5wJauZxZ4x5O9AiOSBaguhYGqmHmDJv3CXm9GB45l9LzCjD4//29sAVazOELv0oQIAAAAAElFTkSuQmCC);
 }
 
-.cm-s-neat span.cm-comment { color: #008000; }
-.cm-s-neat span.cm-keyword { line-height: 1em; font-weight: bold; color: blue; }
-.cm-s-neat span.cm-string { color: #B21543; }
-.cm-s-neat span.cm-builtin { line-height: 1em; font-weight: bold; color: #077; }
-.cm-s-neat span.cm-special { line-height: 1em; font-weight: bold; color: #0aa; }
-.cm-s-neat span.cm-variable { color: black; }
-.cm-s-neat span.cm-number, .cm-s-neat span.cm-atom { color: #3a3; }
-.cm-s-neat span.cm-meta {color: #555;}
-.cm-s-neat span.cm-link { color: #3a3; }
+.cm-s-ipython span.cm-comment { color: #008000; }
+.cm-s-ipython span.cm-keyword { line-height: 1em; font-weight: bold; color: blue; }
+.cm-s-ipython span.cm-string { color: #B21543; }
+.cm-s-ipython span.cm-builtin { line-height: 1em; font-weight: bold; color: #077; }
+.cm-s-ipython span.cm-special { line-height: 1em; font-weight: bold; color: #0aa; }
+.cm-s-ipython span.cm-variable { color: black; }
+.cm-s-ipython span.cm-number, .cm-s-ipython span.cm-atom { color: #3a3; }
+.cm-s-ipython span.cm-meta {color: #555;}
+.cm-s-ipython span.cm-link { color: #3a3; }
 
-.cm-s-neat .CodeMirror-activeline-background {background: #e8f2ff !important;}
-.cm-s-neat .CodeMirror-matchingbracket {outline:1px solid grey; color:black !important;}
+.cm-s-ipython .CodeMirror-activeline-background {background: #e8f2ff !important;}
+.cm-s-ipython .CodeMirror-matchingbracket {outline:1px solid grey; color:black !important;}
 
-.cm-s-neat.CodeMirror {
+.cm-s-ipython.CodeMirror {
     font-family: "Fira Code", Consolas, Monaco, Menlo, "Andale Mono", "lucida console", "Courier New", monospace !important;
     font-feature-settings: "calt" 1;
     box-shadow: inset 0 0 2px black;
+    background: #f5f5f5;
+}
+
+.cm-s-ipython .CodeMirror-line {
+    color: dimgray;
 }


### PR DESCRIPTION
A user has an ability to apply themes using projects like jupyter-themes (sets custom.css).
For an F# code in notebook VisualStudio-like colouring is applied.
Added white background for "dark" themes

Dark theme example:
![image](https://user-images.githubusercontent.com/2181580/42369698-6b420b5a-8113-11e8-9d63-242b7216a82c.png)
