### PR TITLE
Add IFSHARP define

### DIFF
--- a/src/IfSharp.Kernel/Evaluation.fs
+++ b/src/IfSharp.Kernel/Evaluation.fs
@@ -55,7 +55,7 @@ module Evaluation =
             fsiObj.PrintWidth <- 10
             fsiObj.PrintSize <- 10
         let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration(fsiObj, false)
-        let args = [|"--noninteractive"; "--define:HAS_FSI_ADDHTMLPRINTER" |]
+        let args = [|"--noninteractive"; "--define:HAS_FSI_ADDHTMLPRINTER"; "--define:IFSHARP" |]
         let fsiSession = FsiEvaluationSession.Create(fsiConfig, args, inStream, outStream, errStream)
 
         // Load the `fsi` object from the right location of the `FSharp.Compiler.Interactive.Settings.dll`

--- a/src/IfSharp.Kernel/Evaluation.fs
+++ b/src/IfSharp.Kernel/Evaluation.fs
@@ -55,7 +55,7 @@ module Evaluation =
             fsiObj.PrintWidth <- 10
             fsiObj.PrintSize <- 10
         let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration(fsiObj, false)
-        let args = [|"--noninteractive"; "--define:HAS_FSI_ADDHTMLPRINTER"; "--define:IFSHARP" |]
+        let args = [|"--noninteractive"; "--define:HAS_FSI_ADDHTMLPRINTER"; "--define:IFSHARP"; "--define:JUPYTER" |]
         let fsiSession = FsiEvaluationSession.Create(fsiConfig, args, inStream, outStream, errStream)
 
         // Load the `fsi` object from the right location of the `FSharp.Compiler.Interactive.Settings.dll`


### PR DESCRIPTION
It is reasonable for load scripts to configure themselves based on host.   We already have HAS_FSI_ADDHTMLPRINTER, and it is better to use host capabilities like this, but also having a host define is sensible.

