### PR TITLE
Fix Docker compilation / build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM mono:5.12.0.226
+FROM mono:5.18.0.225
 
 RUN apt update \
     && apt install -y \
         python3-pip \
         git
 
-RUN pip3 install --upgrade setuptools pip && pip3 install jupyter
+RUN python3 -m pip install --upgrade setuptools pip && python3 -m pip install jupyter
 
 WORKDIR /
 RUN git clone https://github.com/fsprojects/IfSharp.git


### PR DESCRIPTION
Received 2 separate errors during build

1. Build could not find 4.7.2 libraries.  This was fixed by upgrading mono version to 5.18 (latest).
2. Build could not run the pip3 command.  Fixed using advice from https://github.com/pypa/pip/issues/5221#issuecomment-382069604