### PR TITLE
Fix .Net core Intellisense issue

### DIFF
--- a/src/IfSharp.Kernel/Evaluation.fs
+++ b/src/IfSharp.Kernel/Evaluation.fs
@@ -113,8 +113,8 @@ module Evaluation =
 
         let options, errors =
             fsiEval.InteractiveChecker.GetProjectOptionsFromScript(
-                  scriptFileName, source, assumeDotNetFramework = assumeDotNetFramework)
-           |> Async.RunSynchronously
+                scriptFileName, source, assumeDotNetFramework = assumeDotNetFramework)
+            |> Async.RunSynchronously
 
         // dotnet core is does not return System.Runtime.dll when assumeDotNetFramework is set
         // to false, add it here

--- a/src/IfSharp.Kernel/Evaluation.fs
+++ b/src/IfSharp.Kernel/Evaluation.fs
@@ -7,7 +7,7 @@ open FSharp.Compiler.SourceCodeServices
 open FSharp.Compiler.Interactive.Shell
 
 [<AutoOpen>]
-module Evaluation = 
+module Evaluation =
     open FSharp.Compiler
 
     type SimpleDeclaration =
@@ -18,16 +18,16 @@ module Evaluation =
             Value: string
         }
 
-    /// Extend the `fsi` object with `fsi.AddHtmlPrinter` 
+    /// Extend the `fsi` object with `fsi.AddHtmlPrinter`
     let addHtmlPrinter = """
-        module FsInteractiveService = 
+        module FsInteractiveService =
             let mutable htmlPrinters = new ResizeArray<System.Type * (obj -> seq<string * string> * string)>()
             let htmlPrinterParams = System.Collections.Generic.Dictionary<string, obj>()
             do htmlPrinterParams.["html-standalone-output"] <- false
 
         type Microsoft.FSharp.Compiler.Interactive.Shell.FsiEvaluationSession with
             member x.HtmlPrinterParameters = FsInteractiveService.htmlPrinterParams
-            member x.AddHtmlPrinter<'T>(f:'T -> seq<string * string> * string) = 
+            member x.AddHtmlPrinter<'T>(f:'T -> seq<string * string> * string) =
                 FsInteractiveService.htmlPrinters.Add(typeof<'T>, fun (value:obj) ->
                     f (value :?> 'T))"""
 
@@ -40,8 +40,8 @@ module Evaluation =
         let outStream = new StringWriter(sbOut)
         let errStream = new StringWriter(sbErr)
         let printStream = new StringWriter(sbPrint)
-    
-        
+
+
 
         let fsiObj = FSharp.Compiler.Interactive.Shell.Settings.fsi
         // The following is a workaround for IfSharp github issue #143
@@ -63,13 +63,13 @@ module Evaluation =
         // Load the `fsi` object from the right location of the `FSharp.Compiler.Interactive.Settings.dll`
         // assembly and add the `fsi.AddHtmlPrinter` extension method; then clean it from FSI output
         let origLength = sbOut.Length
-        let fsiLocation = typeof<FSharp.Compiler.Interactive.Shell.Settings.InteractiveSettings>.Assembly.Location    
+        let fsiLocation = typeof<FSharp.Compiler.Interactive.Shell.Settings.InteractiveSettings>.Assembly.Location
         let _, errors1 = fsiSession.EvalInteractionNonThrowing("#r @\"" + fsiLocation + "\"")
         let _, errors2 = fsiSession.EvalInteractionNonThrowing(addHtmlPrinter)
-        sbOut.Remove(origLength, sbOut.Length-origLength) |> ignore        
+        sbOut.Remove(origLength, sbOut.Length-origLength) |> ignore
 
         // Get reference to the extra HTML printers registered inside the FSI session
-        let extraPrinters = 
+        let extraPrinters =
             unbox<ResizeArray<System.Type * (obj -> seq<string * string> * string)>>
                 (fsiSession.EvalExpression("FsInteractiveService.htmlPrinters").Value.ReflectionValue)
 
@@ -82,7 +82,7 @@ module Evaluation =
     /// Gets `it` only if `it` was printed to the console
     let GetLastExpression() =
 
-        let lines = 
+        let lines =
             sbOut.ToString().Split('\r', '\n')
             |> Seq.filter (fun x -> x <> "")
             |> Seq.toArray
@@ -90,7 +90,7 @@ module Evaluation =
         let index = lines |> Seq.tryFindIndex (fun x -> x.StartsWith("val it :"))
         if index.IsSome then
             //We could display more of these errors but the errors may be confusing. Consider.
-            try 
+            try
                 let result, errors = fsiEval.EvalExpressionNonThrowing("it")
                 match result with
                 | Choice1Of2 (Some value) -> Some value
@@ -98,25 +98,37 @@ module Evaluation =
                 | Choice2Of2 (exn:exn) -> None
 
             with _ -> None
-        else 
+        else
             None
 
     /// New way of getting the declarations
-    let GetDeclarations(source, lineNumber, charIndex) = 
+    let GetDeclarations (runtime : Config.Runtime) (source, lineNumber, charIndex) =
 
         let scriptFileName = Path.Combine(Environment.CurrentDirectory, "script.fsx")
+
+        let assumeDotNetFramework =
+            match runtime with
+            | Config.Runtime.NetCore -> false
+            | Config.Runtime.NetFramework -> true
+
         let options, errors =
             fsiEval.InteractiveChecker.GetProjectOptionsFromScript(
-                scriptFileName, source, assumeDotNetFramework = false)
-            |> Async.RunSynchronously
+                  scriptFileName, source, assumeDotNetFramework = assumeDotNetFramework)
+           |> Async.RunSynchronously
 
-        let corelib = "System.Private.CoreLib.dll"
-        let runtime =
-            options.OtherOptions
-            |> Array.find (fun v -> v.Contains(corelib))
-            |> (fun v -> v.Replace(corelib, "System.Runtime.dll"))
-        let other = options.OtherOptions |> Array.append [|runtime|]
-        let options = { options with OtherOptions = other }
+        // dotnet core is does not return System.Runtime.dll when assumeDotNetFramework is set
+        // to false, add it here
+        let options =
+            match runtime with
+            | Config.Runtime.NetCore ->
+                let corelib = "System.Private.CoreLib.dll"
+                let runtime =
+                    options.OtherOptions
+                    |> Array.find (fun v -> v.Contains(corelib))
+                    |> (fun v -> v.Replace(corelib, "System.Runtime.dll"))
+                let other = options.OtherOptions |> Array.append [|runtime|]
+                { options with OtherOptions = other }
+            | Config.Runtime.NetFramework -> options
 
         let (parseFileResults, checkFileAnswer) =
             fsiEval.InteractiveChecker.ParseAndCheckFileInProject(scriptFileName, 0, source, options)
@@ -124,7 +136,7 @@ module Evaluation =
 
         let checkFileResults =
             match checkFileAnswer with
-            | FSharpCheckFileAnswer.Aborted -> failwith (sprintf "fsiEval.InteractiveChecker.ParseAndCheckFileInProject returned FSharpCheckFileAnswer.Aborted. %s:%d:%d %A %A" source lineNumber charIndex errors options)
+            | FSharpCheckFileAnswer.Aborted -> failwith (sprintf "fsiEval.InteractiveChecker.ParseAndCheckFileInProject returned FSharpCheckFileAnswer.Aborted. %s:%d:%d" source lineNumber charIndex)
             | FSharpCheckFileAnswer.Succeeded x -> x
 
         try
@@ -141,31 +153,31 @@ module Evaluation =
 
                     //https://github.com/fsharp/FSharp.Compiler.Service/issues/835
                     //Particularly suggestion it should be folded into GetDeclarationListInfo, and perhaps we should move to the F# AST as well
-                    let partialName = QuickParse.GetPartialLongNameEx(line, charIndex-1) 
+                    let partialName = QuickParse.GetPartialLongNameEx(line, charIndex-1)
 
                     let decls =
                         checkFileResults.GetDeclarationListInfo(Some parseFileResults, lineNumber, line, partialName)
                         |> Async.RunSynchronously
 
                     // get declarations for a location
-                    (*let decls = 
+                    (*let decls =
                         checkFileResults.GetDeclarationListInfo(Some(parseFileResults), lineNumber, charIndex, line, names, filterString, (fun _ -> []))
                         |> Async.RunSynchronously*)
 
-                    let items = 
+                    let items =
                         decls.Items
                         |> Array.filter (fun x -> x.Name.StartsWith(filterString, StringComparison.OrdinalIgnoreCase))
                         |> Array.map (fun x -> { Documentation = formatTip(x.DescriptionText, None); Glyph = x.Glyph; Name = x.Name; Value = getValue x.Name })
 
                     (items, checkFileResults, startIdx, filterString)
-                | None -> 
+                | None ->
                     ([||], checkFileResults, charIndex, "")
-            | Some(x) -> 
+            | Some(x) ->
 
-                let items = 
+                let items =
                     x.Matches
                     |> Array.map (fun x -> { Documentation = matchToDocumentation x; Glyph = matchToGlyph x.MatchType; Name = x.Name; Value = x.Name })
-                
+
                 (items, checkFileResults, x.FilterStartIndex, "")
         with _ ->
             ([||], checkFileResults, 0, "")

--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -475,7 +475,7 @@ open IfSharp.Kernel.Globals"""
         let realLineNumber = position.line + lineOffset + 1
         let codeString = String.Join("\n", codes)
 
-        let (decls, tcr, filterStartIndex, filterString) = GetDeclarations(codeString, realLineNumber, position.ch)
+        let (decls, tcr, filterStartIndex, filterString) = GetDeclarations runtime (codeString, realLineNumber, position.ch)
         
         let matches = 
             decls


### PR DESCRIPTION
This is a fix for issue #201.

I have also cleaned up the whitespace in `src/IfSharp.Kernel/Evaluation.fs`. 