### PR TITLE
Fixed incorrect assembly name references

### DIFF
--- a/src/IfSharp/AssemblyInfo.fs
+++ b/src/IfSharp/AssemblyInfo.fs
@@ -1,4 +1,4 @@
-﻿namespace IFSharp.AssemblyInfo
+﻿namespace IfSharp.AssemblyInfo
 
 open System.Reflection
 open System.Runtime.CompilerServices
@@ -7,11 +7,11 @@ open System.Runtime.InteropServices
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[<assembly: AssemblyTitle("IFSharp")>]
+[<assembly: AssemblyTitle("IfSharp")>]
 [<assembly: AssemblyDescription("")>]
 [<assembly: AssemblyConfiguration("")>]
 [<assembly: AssemblyCompany("")>]
-[<assembly: AssemblyProduct("IFSharp")>]
+[<assembly: AssemblyProduct("IfSharp")>]
 [<assembly: AssemblyCopyright("Copyright ©  2019")>]
 [<assembly: AssemblyTrademark("")>]
 [<assembly: AssemblyCulture("")>]

--- a/src/IfSharp/IfSharp.fsproj
+++ b/src/IfSharp/IfSharp.fsproj
@@ -8,12 +8,12 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>614109a5-ec07-47da-be73-d91ccc08fb4f</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>IFSharp</RootNamespace>
+    <RootNamespace>IfSharp</RootNamespace>
     <AssemblyName>ifsharp</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <UseStandardResourceNames>true</UseStandardResourceNames>
-    <Name>IFSharp</Name>
+    <Name>IfSharp</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -149,7 +149,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <ProjectReference Include="..\IfSharp.Kernel\IfSharp.Kernel.fsproj">
-      <Name>IFSharp.Kernel</Name>
+      <Name>IfSharp.Kernel</Name>
       <Project>{25fe52cd-bce3-471d-a629-9dc9f0410b6c}</Project>
       <Private>True</Private>
     </ProjectReference>


### PR DESCRIPTION
There are quite a few assembly references which have incorrectly reference `IFSharp` rather than `IfSharp`. This PR just aims to make it more uniform.