### PR TITLE
Workaround for Jupyter Labs 

### DIFF
--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -173,7 +173,7 @@ open IfSharp.Kernel.Globals"""
         
         let header           = JsonConvert.DeserializeObject<Header>(headerJson)
         let parentHeader     = JsonConvert.DeserializeObject<Header>(parentHeaderJson)
-        let metaDataDict     = deserializeDict (metadata)
+        //let metaDataDict     = deserializeDict (metadata) //We don't currently need metadata and it's changing between notebooks and labs
         let content          = ShellMessages.Deserialize (header.msg_type) (contentJson)
 
         let calculated_signature = sign [headerJson; parentHeaderJson; metadata; contentJson]


### PR DESCRIPTION
Jupyter Labs is sending extra information in meta e.g. "deletedCells". We don't currently use this so avoid deserializing as there's a problem with that!

Note there are outstanding issues in Jupyter Labs:
- Code highlighting not enabled (using default)
- Code completion not enabled
- Plotting results not shown

They'll all need someone to follow up later but at least this loads and runs for me:

![image](https://user-images.githubusercontent.com/1099725/55290220-5f5ce980-53c8-11e9-83f2-8d402b06f7c6.png)
