### PR TITLE
If expression can't be evaluated e.g. it's unconstrained then just give string

### DIFF
--- a/src/IfSharp.Kernel/Kernel.fs
+++ b/src/IfSharp.Kernel/Kernel.fs
@@ -432,10 +432,13 @@ open IfSharp.Kernel.Globals"""
                     if not content.silent then
                         let lastExpression = GetLastExpression()
                         match lastExpression with
-                        | Some(it) -> 
-                            if it.ReflectionType <> typeof<unit> then
-                                produceOutput it.ReflectionValue true
-                        | None -> ()
+                        | ActualValue(fsiValue) -> 
+                            if fsiValue.ReflectionType <> typeof<unit> then
+                                produceOutput fsiValue.ReflectionValue true
+                        | BackupString str ->
+                            let display_id = Guid.NewGuid()
+                            sendDisplayData "text/plain" str "display_data" (display_id.ToString())
+                        | Empty -> ()
 
 
                 | Choice2Of2 exn ->


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1099725/59354297-c843d480-8d1c-11e9-83f3-9ae540de98d0.png)

closes #153