### PR TITLE
Utils.Table propertyName order

### DIFF
--- a/FSharp_Jupyter_Notebooks.ipynb
+++ b/FSharp_Jupyter_Notebooks.ipynb
@@ -633,13 +633,13 @@
     {
      "data": {
       "text/html": [
-       "<table><thead><tr><th>FirstName</th><th>LastName</th></tr></thead><tbody><tr><td>Walter</td><td>Harp</td></tr><tr><td>Jeff</td><td>Smith</td></tr><tr><td>Ben</td><td>Smith</td></tr><tr><td></td><td>Holly</td></tr><tbody></tbody></table>"
+       "<table><thead><tr><th>FirstName</th><th>LastName</th><th>Age</th></tr></thead><tbody><tr><td>Walter</td><td>Harp</td><td>31</td></tr><tr><td>Jeff</td><td>Smith</td><td>21</td></tr><tr><td>Ben</td><td>Smith</td><td>65</td></tr><tr><td></td><td>Holly</td><td>44</td></tr><tbody></tbody></table>"
       ],
       "text/plain": [
-       "{Columns = [|\"FirstName\"; \"LastName\"|];\n",
+       "{ Columns = [|\"FirstName\"; \"LastName\"; \"Age\"|]\n",
        " Rows =\n",
-       "  [|[|\"Walter\"; \"Harp\"|]; [|\"Jeff\"; \"Smith\"|]; [|\"Ben\"; \"Smith\"|];\n",
-       "    [|\"\"; \"Holly\"|]|];}"
+    "        [|[|\"Walter\"; \"Harp\"; \"31\"|]; [|\"Jeff\"; \"Smith\"; \"21\"|];\n",
+    "          [|\"Ben\"; \"Smith\"; \"65\"|]; [|\"\"; \"Holly\"; \"44\"|]|] }"
       ]
      },
      "execution_count": 19,
@@ -648,15 +648,14 @@
     }
    ],
    "source": [
-    "type MyType = { FirstName: string; LastName: string }\n",
+    "type MyType = { FirstName: string; LastName: string; Age : int }\n",
     "let records = \n",
     "    [|\n",
-    "        { FirstName = \"Walter\"; LastName = \"Harp\" }\n",
-    "        { FirstName = \"Jeff\"; LastName = \"Smith\" }\n",
-    "        { FirstName = \"Ben\"; LastName = \"Smith\" }\n",
-    "        { FirstName = \"\"; LastName = \"Holly\" }\n",
+    "        { FirstName = \"Walter\"; LastName = \"Harp\"; Age = 31 }\n",
+    "        { FirstName = \"Jeff\"; LastName = \"Smith\"; Age = 21 }\n",
+    "        { FirstName = \"Ben\"; LastName = \"Smith\"; Age = 65 }\n",
+    "        { FirstName = \"\"; LastName = \"Holly\"; Age= 44 }\n",
     "    |]\n",
-    "\n",
     "records |> Util.Table"
    ]
   },
@@ -664,7 +663,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also filter the table to display a subset of the data as you display it:"
+    "You can also filter the table to display a subset of the data as you display it. This also sets the order of the columns:"
    ]
   },
   {
@@ -675,11 +674,13 @@
     {
      "data": {
       "text/html": [
-       "<table><thead><tr><th>LastName</th></tr></thead><tbody><tr><td>Harp</td></tr><tr><td>Smith</td></tr><tr><td>Smith</td></tr><tr><td>Holly</td></tr><tbody></tbody></table>"
+       "<table><thead><tr><th>Age</th><th>LastName</th></tr></thead><tbody><tr><td>31</td><td>Harp</td></tr><tr><td>21</td><td>Smith</td></tr><tr><td>65</td><td>Smith</td></tr><tr><td>44</td><td>Holly</td></tr><tbody></tbody></table>"
       ],
       "text/plain": [
-       "{Columns = [|\"LastName\"|];\n",
-       " Rows = [|[|\"Harp\"|]; [|\"Smith\"|]; [|\"Smith\"|]; [|\"Holly\"|]|];}"
+       "{ Columns = [|\"Age\"; \"LastName\"|]\n",
+       "  Rows =\n",
+       "        [|[|\"31\"; \"Harp\"|]; [|\"21\"; \"Smith\"|]; [|\"65\"; \"Smith\"|];\n",
+       "          [|\"44\"; \"Holly\"|]|] }"
       ]
      },
      "execution_count": 20,
@@ -688,7 +689,7 @@
     }
    ],
    "source": [
-    "Util.Table(records, [| \"LastName\" |])"
+    "Util.Table(records, [| \"Age\"; \"LastName\" |])"
    ]
   },
   {


### PR DESCRIPTION
Use the order of the propertyNames (when given) for the order of the columns in the table.

Updated example in `FSharp_Jupyter_Notebooks.ipynb`